### PR TITLE
Add Cylc Site/User config to list of rendered files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
                 "filenamePatterns": [
                     "suite*.rc",
                     "suite*.rc.*",
-                    "*.cylc"
+                    "*.cylc",
+                    "flow.rc",
+                    "flow-tests.rc"
                 ],
                 "configuration": "./cylc.language-configuration.json"
             }


### PR DESCRIPTION
Whilst the format of the `flow.rc` and `flow-tests.rc` is slightly different I believe that this is still the best rendering for these files.